### PR TITLE
feat: fully headless fresh install — env knobs replace blocking prompts

### DIFF
--- a/docs/PAYRAM_HEADLESS_AGENT.md
+++ b/docs/PAYRAM_HEADLESS_AGENT.md
@@ -74,8 +74,13 @@ with the exact fix command, and a non-zero exit.
   running container); default `http://localhost` (the installer publishes
   `80:80`). Override with `PAYRAM_API_URL` only if you know better.
 - Docker required if `PAYRAM_NODE_MODE=docker` (default) for JS tooling.
-- A **fresh install needs a TTY** (the installer prompts for DB/SSL/ports). Run
-  it once interactively; every step after that is fully headless.
+- A **fresh install is fully headless** — without a TTY the installer resolves
+  every choice from env knobs with deterministic defaults: containerized DB,
+  no SSL (add later), HTTP on port 80 (first free of 8080/8081/8088/8888 if 80
+  is busy). Override with `PAYRAM_DB_MODE`, `PAYRAM_SSL_MODE`,
+  `PAYRAM_HOST_PORT`. Anything ambiguous (external DB without credentials,
+  letsencrypt without `DOMAIN_NAME`/`LE_EMAIL`, chosen port busy, low disk)
+  **fails fast naming the exact env var to set** — it never hangs on a prompt.
 
 ---
 
@@ -121,6 +126,11 @@ Set these for non-interactive or scripted runs. For agents, prefer env-driven, n
 | `PAYRAM_CUSTOMER_ID` | from signin | Usually from token file after signin |
 | `PAYRAM_FRONTEND_URL` | `http://localhost` | Used by ensure-config (local) |
 | `PAYRAM_NETWORK` | `testnet` | One-step flow network selection (`testnet` or `mainnet`) |
+| **headless fresh install** | | |
+| `PAYRAM_DB_MODE` | `internal` | `internal` (containerized) or `external` (needs `DB_NAME`, `DB_USER`, `DB_PASSWORD`; `DB_HOST`/`DB_PORT` default `localhost`/`5432`) |
+| `PAYRAM_SSL_MODE` | `none` | `none`, `letsencrypt` (needs `DOMAIN_NAME` + `LE_EMAIL`), or `custom` (certs already in place) |
+| `PAYRAM_HOST_PORT` | `80` (auto-fallback) | Host port publishing HTTP; agent auto-picks first free of 80/8080/8081/8088/8888 |
+| `PAYRAM_NONINTERACTIVE` | auto (no TTY) | Set `1` to force headless prompts even with a TTY |
 | `PAYRAM_NODE_MODE` | `docker` | JS runtime: `docker` or `host` |
 | `PAYRAM_NODE_DOCKER_IMAGE` | `node:20-bullseye-slim` | Docker image used for JS scripts |
 | **deploy-scw** | | |
@@ -196,7 +206,7 @@ Rules agents must know:
 The one-step flow does:
 
 1. Network selection (`testnet` or `mainnet`) unless `PAYRAM_NETWORK` is set.
-2. Install or restart PayRam using `setup_payram.sh` (fresh install needs a TTY).
+2. Install or restart PayRam using `setup_payram.sh` (fresh install works headless — env-knob defaults; see Prerequisites).
 3. Re-reads `config.env` and waits for API readiness at the real port.
 4. Auth (`setup` if no root user, else `signin`).
 5. `ensure-config` for local frontend/backend settings.

--- a/setup_payram.sh
+++ b/setup_payram.sh
@@ -8,6 +8,21 @@ set -euo pipefail
 # Supports: Ubuntu, Debian, CentOS, RHEL, Fedora, Arch, Alpine
 # =============================================================================
 
+# --- NON-INTERACTIVE (HEADLESS) INSTALL SUPPORT ---
+# When PAYRAM_NONINTERACTIVE=1 is set, or stdin is not a terminal, fresh-install
+# prompts stop blocking and resolve from environment variables with safe
+# defaults. Anything ambiguous fails fast with a clear message instead of
+# guessing. Interactive (TTY) behavior is unchanged unless a PAYRAM_* knob is
+# explicitly set. Knobs honored on a fresh install:
+#   PAYRAM_DB_MODE    internal (default) | external  — external needs DB_NAME,
+#                     DB_USER, DB_PASSWORD (DB_HOST/DB_PORT default localhost/5432)
+#   PAYRAM_SSL_MODE   none (default) | letsencrypt | custom — letsencrypt needs
+#                     DOMAIN_NAME + LE_EMAIL; custom needs DOMAIN_NAME + certs in place
+#   PAYRAM_HOST_PORT  host port published for HTTP (default 80; must be free)
+is_noninteractive() {
+  [[ "${PAYRAM_NONINTERACTIVE:-0}" == "1" || ! -t 0 ]]
+}
+
 # --- GLOBAL SYSTEM INFORMATION ---
 # Note: declare -g (bash 4.2+) is not used here; plain assignments work on bash 3.2+ (macOS default)
 OS_FAMILY=""
@@ -793,6 +808,12 @@ check_disk_space_requirements() {
       print_color "blue" "💡 Note: You can increase disk space after installation if needed."
       echo
       
+      if is_noninteractive; then
+        print_color "red" "❌ Not enough disk space for an unattended install (needs 5GB+ free)."
+        print_color "gray" "   Free space (docker system prune -a, apt clean) and re-run."
+        return 1
+      fi
+
       while true; do
         print_color "yellow" "Do you want to continue anyway? (y/N): "
         read -r response
@@ -950,6 +971,26 @@ configure_database() {
   print_color "gray" "   • Best for: Testing, development, and small-scale usage"
   echo
   
+  # Headless / env-pinned choice: PAYRAM_DB_MODE=internal|external.
+  # Unattended default is the containerized DB — zero extra inputs needed.
+  if [[ -n "${PAYRAM_DB_MODE:-}" ]] || is_noninteractive; then
+    case "${PAYRAM_DB_MODE:-internal}" in
+      external)
+        print_color "blue" "→ Database: external PostgreSQL (PAYRAM_DB_MODE)"
+        configure_external_database
+        ;;
+      internal)
+        print_color "blue" "→ Database: containerized PostgreSQL (${PAYRAM_DB_MODE:+via PAYRAM_DB_MODE=}${PAYRAM_DB_MODE:-headless default})"
+        configure_internal_database
+        ;;
+      *)
+        print_color "red" "❌ Invalid PAYRAM_DB_MODE='${PAYRAM_DB_MODE}'. Use 'internal' or 'external'."
+        exit 1
+        ;;
+    esac
+    return 0
+  fi
+
   while true; do
     read -e -p "Select option (1-2): " choice
     case $choice in
@@ -977,10 +1018,34 @@ configure_external_database() {
   print_color "gray" "  • Network connectivity (check firewalls if connection fails)"
   echo
   
+  # Headless: take connection details from the environment, test once, no retry
+  # loop. Required: DB_NAME, DB_USER, DB_PASSWORD. Optional: DB_HOST, DB_PORT.
+  if is_noninteractive; then
+    DB_HOST="${DB_HOST:-localhost}"
+    DB_PORT="${DB_PORT:-5432}"
+    local missing=""
+    [[ -z "${DB_NAME:-}" ]] && missing="$missing DB_NAME"
+    [[ -z "${DB_USER:-}" ]] && missing="$missing DB_USER"
+    [[ -z "${DB_PASSWORD:-}" ]] && missing="$missing DB_PASSWORD"
+    if [[ -n "$missing" ]]; then
+      print_color "red" "❌ External DB selected but missing env:${missing}"
+      print_color "gray" "   Export them and re-run, or use PAYRAM_DB_MODE=internal."
+      exit 1
+    fi
+    print_color "blue" "🔍 Testing database connection (headless)..."
+    if test_postgres_connection; then
+      print_color "green" "✅ Database connection successful!"
+      return 0
+    fi
+    print_color "red" "❌ Could not connect to ${DB_HOST}:${DB_PORT}/${DB_NAME} as ${DB_USER}."
+    print_color "gray" "   Check host/credentials/firewall, or use PAYRAM_DB_MODE=internal."
+    exit 1
+  fi
+
   while true; do
     read -e -p "Database Host [localhost]: " DB_HOST
     DB_HOST=${DB_HOST:-localhost}
-    
+
     read -e -p "Database Port [5432]: " DB_PORT
     DB_PORT=${DB_PORT:-5432}
     
@@ -1107,6 +1172,31 @@ configure_ssl() {
   print_color "gray" "   • You can add SSL certificates anytime when ready"
   echo
 
+  # Headless / env-pinned choice: PAYRAM_SSL_MODE=none|letsencrypt|custom.
+  # Unattended default is none (HTTP) — SSL needs DNS facts an agent may not
+  # have; it can be added later via the SSL update flow.
+  if [[ -n "${PAYRAM_SSL_MODE:-}" ]] || is_noninteractive; then
+    case "${PAYRAM_SSL_MODE:-none}" in
+      letsencrypt)
+        print_color "blue" "→ SSL: Let's Encrypt (PAYRAM_SSL_MODE)"
+        configure_ssl_letsencrypt
+        ;;
+      custom)
+        print_color "blue" "→ SSL: custom certificates (PAYRAM_SSL_MODE)"
+        configure_ssl_custom
+        ;;
+      none|external)
+        print_color "blue" "→ SSL: none for now (${PAYRAM_SSL_MODE:+via PAYRAM_SSL_MODE=}${PAYRAM_SSL_MODE:-headless default}) — HTTP on port 80"
+        configure_ssl_external
+        ;;
+      *)
+        print_color "red" "❌ Invalid PAYRAM_SSL_MODE='${PAYRAM_SSL_MODE}'. Use 'none', 'letsencrypt', or 'custom'."
+        exit 1
+        ;;
+    esac
+    return 0
+  fi
+
   while true; do
     read -e -p "Select option (1-3): " choice
     case $choice in
@@ -1140,40 +1230,34 @@ configure_ssl_letsencrypt() {
   print_color "gray" "  • No other web server using these ports"
   echo
   
-  # Domain input with validation
-  while true; do
-    read -e -p "Enter your domain name (e.g., payram.example.com): " DOMAIN_NAME
-    
-    if [[ -z "$DOMAIN_NAME" ]]; then
-      print_color "red" "Domain name cannot be empty"
-      continue
+  # Headless: domain + email must come from the environment — there is no
+  # sane default for DNS facts. Fail fast with the exact knobs to set.
+  if is_noninteractive; then
+    if [[ -z "${DOMAIN_NAME:-}" || -z "${LE_EMAIL:-}" ]]; then
+      print_color "red" "❌ PAYRAM_SSL_MODE=letsencrypt needs DOMAIN_NAME and LE_EMAIL env vars."
+      print_color "gray" "   Export both and re-run, or use PAYRAM_SSL_MODE=none and add SSL later."
+      exit 1
     fi
-    
-    # Basic domain validation
-    if [[ ! "$DOMAIN_NAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$ ]]; then
+  fi
+
+  # Domain input with validation (skipped when DOMAIN_NAME is pre-set)
+  while [[ -z "${DOMAIN_NAME:-}" ]] || [[ ! "$DOMAIN_NAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$ ]]; do
+    if [[ -n "${DOMAIN_NAME:-}" ]]; then
       print_color "red" "Invalid domain format. Please use format: payram.example.com"
-      continue
+      if is_noninteractive; then exit 1; fi
     fi
-    
-    break
+    read -e -p "Enter your domain name (e.g., payram.example.com): " DOMAIN_NAME
+    [[ -z "$DOMAIN_NAME" ]] && print_color "red" "Domain name cannot be empty"
   done
-  
-  # Email for Let's Encrypt notifications
-  while true; do
-    read -e -p "Enter email for SSL notifications (certificate expiry alerts): " LE_EMAIL
-    
-    if [[ -z "$LE_EMAIL" ]]; then
-      print_color "red" "Email cannot be empty"
-      continue
-    fi
-    
-    # Basic email validation
-    if [[ ! "$LE_EMAIL" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+
+  # Email for Let's Encrypt notifications (skipped when LE_EMAIL is pre-set)
+  while [[ -z "${LE_EMAIL:-}" ]] || [[ ! "$LE_EMAIL" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; do
+    if [[ -n "${LE_EMAIL:-}" ]]; then
       print_color "red" "Invalid email format"
-      continue
+      if is_noninteractive; then exit 1; fi
     fi
-    
-    break
+    read -e -p "Enter email for SSL notifications (certificate expiry alerts): " LE_EMAIL
+    [[ -z "$LE_EMAIL" ]] && print_color "red" "Email cannot be empty"
   done
   
   echo
@@ -1183,7 +1267,14 @@ configure_ssl_letsencrypt() {
   print_color "gray" "  • This process takes 1-3 minutes"
   echo
   
-  read -e -p "Ready to generate SSL certificate? (y/N): " confirm
+  local confirm
+  if is_noninteractive; then
+    # Headless: PAYRAM_SSL_MODE=letsencrypt + DOMAIN_NAME + LE_EMAIL already
+    # encode explicit intent — proceed without blocking.
+    confirm="y"
+  else
+    read -e -p "Ready to generate SSL certificate? (y/N): " confirm
+  fi
   if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     print_color "yellow" "SSL setup cancelled. Continuing without SSL..."
     SSL_CERT_PATH=""
@@ -1221,6 +1312,13 @@ configure_ssl_letsencrypt() {
     print_color "gray" "  • Another web server is running"
     echo
     
+    if is_noninteractive; then
+      # Headless: don't silently downgrade an explicit letsencrypt request to
+      # HTTP — fail with the fix list above, or re-run with PAYRAM_SSL_MODE=none.
+      print_color "red" "❌ Certificate generation failed (headless). Fix the issues above and re-run,"
+      print_color "gray" "   or re-run with PAYRAM_SSL_MODE=none to install on HTTP now and add SSL later."
+      exit 1
+    fi
     read -e -p "Continue without SSL? (y/N): " continue_without_ssl
     if [[ "$continue_without_ssl" =~ ^[Yy]$ ]]; then
       SSL_CERT_PATH=""
@@ -1328,7 +1426,14 @@ configure_ssl_external() {
   print_color "red" "  • Restrict direct access to PayRam ports (firewall rules)"
   echo
   
-  read -e -p "Do you want to continue with external SSL management? (y/N): " confirm_external
+  local confirm_external
+  if is_noninteractive; then
+    # Headless: reaching this function already encodes the no-SSL choice
+    # (PAYRAM_SSL_MODE=none or headless default) — don't block on a confirm.
+    confirm_external="y"
+  else
+    read -e -p "Do you want to continue with external SSL management? (y/N): " confirm_external
+  fi
   if [[ "$confirm_external" =~ ^[Yy]$ ]]; then
     SSL_CERT_PATH=""
     SSL_MODE="external"
@@ -1592,7 +1697,9 @@ generate_aes_key() {
   print_color "red" "  • Regular withdrawal of excess funds to cold wallet"
   echo
   
-  read -e -p "Press [Enter] to generate AES-256 encryption key for hot wallet..."
+  if ! is_noninteractive; then
+    read -e -p "Press [Enter] to generate AES-256 encryption key for hot wallet..."
+  fi
   
   print_color "cyan" "🔮 Summoning cryptographic magic..."
   print_color "yellow" "⚡ Generating quantum-secure randomness..."
@@ -1812,6 +1919,24 @@ configure_port_mapping() {
     fi
     PRIMARY_PORT_MAPPING="80:80 443:443"
     log "INFO" "Port mapping set to $PRIMARY_PORT_MAPPING (internal TLS)"
+    return 0
+  fi
+
+  # Headless / env-pinned: PAYRAM_HOST_PORT picks the published HTTP port
+  # (default 80). Validate once and fail fast — no prompt loop to hang on.
+  if [[ -n "${PAYRAM_HOST_PORT:-}" ]] || is_noninteractive; then
+    host_port="${PAYRAM_HOST_PORT:-80}"
+    if [[ ! "$host_port" =~ ^[0-9]+$ ]] || (( host_port < 1 || host_port > 65535 )); then
+      print_color "red" "❌ Invalid PAYRAM_HOST_PORT='${host_port}'. Use a number between 1 and 65535."
+      exit 1
+    fi
+    if ! is_port_free "$host_port"; then
+      print_color "red" "❌ Host port $host_port is already in use."
+      print_color "gray" "   Find the listener: sudo lsof -i :$host_port — stop it, or set PAYRAM_HOST_PORT to a free port (e.g. 8080)."
+      exit 1
+    fi
+    PRIMARY_PORT_MAPPING="${host_port}:80"
+    log "INFO" "Port mapping set to $PRIMARY_PORT_MAPPING (${PAYRAM_HOST_PORT:+via PAYRAM_HOST_PORT=}${PAYRAM_HOST_PORT:-headless default})"
     return 0
   fi
 
@@ -4067,7 +4192,9 @@ main() {
   print_color "gray" "  • Backup critical: AES key + database data"
   echo
   
-  read -e -p "Press [Enter] to deploy PayRam container..."
+  if ! is_noninteractive; then
+    read -e -p "Press [Enter] to deploy PayRam container..."
+  fi
   
   # Step 7: Deploy container
   if deploy_payram_container; then

--- a/setup_payram_agents.sh
+++ b/setup_payram_agents.sh
@@ -51,6 +51,11 @@ Headless commands:
 Env vars:
 	PAYRAM_NETWORK (testnet|mainnet)
 	PAYRAM_SETUP_MODE (merchant|operator; default merchant)
+	Headless fresh-install knobs (no TTY needed; every prompt resolves from env):
+	PAYRAM_DB_MODE (internal|external; default internal. external needs DB_NAME, DB_USER, DB_PASSWORD [+DB_HOST, DB_PORT])
+	PAYRAM_SSL_MODE (none|letsencrypt|custom; default none. letsencrypt needs DOMAIN_NAME + LE_EMAIL)
+	PAYRAM_HOST_PORT (HTTP host port; default 80, auto-falls back to first free of 8080/8081/8088/8888)
+	PAYRAM_NONINTERACTIVE=1 (force headless even with a TTY)
 	PAYRAM_OPERATOR_BTC_FEE_COLLECTOR, PAYRAM_OPERATOR_EVM_FEE_COLLECTOR
 	PAYRAM_OPERATOR_FEE_BPS (default 100 = 1%, max 1500)
 	PAYRAM_API_URL (default: derived from installed config.env / running container)
@@ -126,6 +131,24 @@ run_as_root() {
 	else
 		"$@"
 	fi
+}
+
+# Pick the host port a headless install publishes HTTP on: 80 when free, else
+# the first free fallback. Deterministic - same machine state, same answer.
+# The installer re-validates whatever we pick (PAYRAM_HOST_PORT).
+pick_free_http_port() {
+	local p
+	for p in 80 8080 8081 8088 8888; do
+		# bash /dev/tcp probe: connect succeeds -> something is listening.
+		if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then
+			echo "$p"
+			return 0
+		fi
+		exec 3>&- 3<&- 2>/dev/null || true
+	done
+	# Every candidate is taken - surface a clear, fixable error.
+	echo "80"
+	return 0
 }
 
 wait_for_api() {
@@ -587,11 +610,19 @@ troubleshoot() {
 			fi
 			;;
 		install-interactive)
-			echo "Fresh install needs a terminal: setup_payram.sh asks for DB/SSL/port choices."
-			echo "  [90%] You ran the one-step flow without a TTY before PayRam was installed."
-			echo "        -> run the install once interactively:  sudo ./setup_payram.sh --testnet"
-			echo "           then re-run this agent flow (it attaches to the existing install)."
-			echo "  [10%] Container exists but is stopped."
+			echo "The install did not complete. Headless installs resolve every choice from"
+			echo "env vars (defaults: internal DB, no SSL, port 80/first free) - the message"
+			echo "above this one names the exact problem. Most likely:"
+			echo "  [40%] Chosen host port is busy."
+			echo "        -> PAYRAM_HOST_PORT=8080 $0 --testnet   (or stop the listener)"
+			echo "  [25%] Disk below the 5GB minimum."
+			echo "        -> docker system prune -a; apt clean; then re-run"
+			echo "  [20%] PAYRAM_SSL_MODE=letsencrypt without DOMAIN_NAME/LE_EMAIL set,"
+			echo "        or PAYRAM_DB_MODE=external without DB_NAME/DB_USER/DB_PASSWORD."
+			echo "        -> export the named vars, or drop back to the defaults"
+			echo "  [10%] Docker missing / image pull failed (network)."
+			echo "        -> docker version; docker logs payram 2>&1 | tail -20"
+			echo "  [ 5%] Container exists but is stopped."
 			echo "        -> $0 --restart"
 			;;
 		auth-env)
@@ -2068,18 +2099,31 @@ flow_main() {
 		log "Restarting PayRam container..."
 		(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --restart)
 	elif ! is_payram_running; then
-		# A FRESH install delegates to setup_payram.sh, which asks interactive
-		# questions (DB/SSL/ports). Without a TTY those prompts would loop
-		# forever - fail fast with directions instead of hanging.
+		# A FRESH install delegates to setup_payram.sh. Without a TTY the
+		# installer runs HEADLESS: every prompt resolves from PAYRAM_* env
+		# knobs with deterministic defaults (internal DB, no SSL, port 80 or
+		# the first free fallback), and ambiguous cases fail fast with the
+		# exact env var to set - the install is fully agent-drivable.
 		if [[ ! -t 0 ]]; then
-			troubleshoot install-interactive
-			exit 1
+			export PAYRAM_NONINTERACTIVE=1
+			export PAYRAM_DB_MODE="${PAYRAM_DB_MODE:-internal}"
+			export PAYRAM_SSL_MODE="${PAYRAM_SSL_MODE:-none}"
+			if [[ -z "${PAYRAM_HOST_PORT:-}" ]]; then
+				export PAYRAM_HOST_PORT="$(pick_free_http_port)"
+			fi
+			log "Headless install: DB=${PAYRAM_DB_MODE} SSL=${PAYRAM_SSL_MODE} port=${PAYRAM_HOST_PORT} (${network_mode})"
+			log "Override with PAYRAM_DB_MODE / PAYRAM_SSL_MODE / PAYRAM_HOST_PORT env vars."
 		fi
 		log "Installing/starting PayRam (${network_mode})..."
+		local install_rc=0
 		if [[ "$network_mode" == "mainnet" ]]; then
-			(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --mainnet)
+			(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --mainnet) || install_rc=$?
 		else
-			(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --testnet)
+			(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --testnet) || install_rc=$?
+		fi
+		if [[ "$install_rc" -ne 0 ]]; then
+			troubleshoot install-interactive
+			exit "$install_rc"
 		fi
 		# The install may have just created config.env - re-derive the real
 		# port/dirs from it rather than keeping pre-install guesses.


### PR DESCRIPTION
Closes the last gap between the agent flow and the installer: a fresh install previously required a TTY (7 blocking prompts under `set -euo pipefail` — EOF = exit, busy-port loop = hang). Agents can now finish a new installation deterministically.

## Installer (`setup_payram.sh`)
`is_noninteractive()` = `PAYRAM_NONINTERACTIVE=1` or stdin not a TTY. Headless, every fresh-install prompt resolves from env with safe defaults; ambiguity fails fast **naming the exact env var**:

| Prompt | Headless behavior |
|---|---|
| DB type | `PAYRAM_DB_MODE` → default **internal** (containerized) |
| External DB details | from `DB_*` env, single connection test, fail-fast listing missing vars |
| SSL menu | `PAYRAM_SSL_MODE` → default **none** (HTTP; add SSL later) |
| LE domain/email | `DOMAIN_NAME` + `LE_EMAIL` required headless; cert failure ≠ silent HTTP downgrade |
| Host port | `PAYRAM_HOST_PORT` → default 80, validated once, clear `lsof` hint when busy |
| AES + deploy press-Enter, low-disk y/N | skipped / fail-fast |

Interactive TTY behavior is byte-for-byte unchanged unless a knob is explicitly set (knobs also work interactively to pin choices).

## Agent (`setup_payram_agents.sh`)
- One-step flow no longer refuses no-TTY fresh installs — exports headless defaults (internal DB, no SSL, `pick_free_http_port`: 80→8080→8081→8088→8888) and delegates
- Install failure routes to a rewritten troubleshoot card (probability-ranked: port busy / disk / missing envs / docker)
- Usage text documents the knobs

## Docs
`PAYRAM_HEADLESS_AGENT.md` (canonical, synced into payram-mcp): TTY-required claims replaced with the headless contract + env table. **Follow-up**: re-copy to payram-mcp/docs/PAYRAM_AGENT_ONBOARDING.md per the sync rule.

## Verified
`bash -n` both scripts; headless unit tests with closed stdin: default port mapping, env override, invalid port/db-mode fast-fail, internal-TLS path unchanged, interactive path preserved.

## Test plan (before develop→main)
Fresh VPS, no TTY: `echo | sudo -E bash setup_payram_agents.sh --testnet` → expect complete install on HTTP:80, then payment link. Busy-port case: occupy 80, re-run, expect auto-fallback to 8080.