### PR TITLE
feat: zero-input auth, port-80-only, $10 either-chain funding, testnet warning

### DIFF
--- a/docs/PAYRAM_HEADLESS_AGENT.md
+++ b/docs/PAYRAM_HEADLESS_AGENT.md
@@ -74,12 +74,13 @@ with the exact fix command, and a non-zero exit.
   running container); default `http://localhost` (the installer publishes
   `80:80`). Override with `PAYRAM_API_URL` only if you know better.
 - Docker required if `PAYRAM_NODE_MODE=docker` (default) for JS tooling.
-- A **fresh install is fully headless** — without a TTY the installer resolves
-  every choice from env knobs with deterministic defaults: containerized DB,
-  no SSL (add later), HTTP on port 80 (first free of 8080/8081/8088/8888 if 80
-  is busy). Override with `PAYRAM_DB_MODE`, `PAYRAM_SSL_MODE`,
+- A **fresh install is fully headless and zero-question** (TTY or not): every
+  choice resolves from env knobs with deterministic defaults: containerized DB,
+  no SSL (add later), HTTP on **port 80** — the bundled nginx inside the
+  container reverse-proxies everything, so 80 (and 443 with TLS) are the only
+  ports PayRam needs. Override with `PAYRAM_DB_MODE`, `PAYRAM_SSL_MODE`,
   `PAYRAM_HOST_PORT`. Anything ambiguous (external DB without credentials,
-  letsencrypt without `DOMAIN_NAME`/`LE_EMAIL`, chosen port busy, low disk)
+  letsencrypt without `DOMAIN_NAME`/`LE_EMAIL`, port 80 busy, low disk)
   **fails fast naming the exact env var to set** — it never hangs on a prompt.
 
 ---
@@ -118,8 +119,8 @@ Set these for non-interactive or scripted runs. For agents, prefer env-driven, n
 | Variable | Default | Notes |
 |----------|---------|--------|
 | `PAYRAM_API_URL` | derived (config.env / container; else `http://localhost`) | Backend API base |
-| `PAYRAM_EMAIL` | — | Root user email (setup/signin) |
-| `PAYRAM_PASSWORD` | — | Root user password |
+| `PAYRAM_EMAIL` | auto-created | Root user email; auto-defaults on first setup, saved to `.payraminfo/root-credentials.env` (600). Change in dashboard |
+| `PAYRAM_PASSWORD` | auto-created | Root password; auto-generated on first setup, same file. Change in dashboard |
 | `PAYRAM_PROJECT_NAME` | `Default Project` | Project name on setup |
 | `PAYRAM_PAYMENT_EMAIL` | — | Customer email for payment link |
 | `PAYRAM_PAYMENT_AMOUNT` | `10` | Amount in USD for payment link |
@@ -129,7 +130,7 @@ Set these for non-interactive or scripted runs. For agents, prefer env-driven, n
 | **headless fresh install** | | |
 | `PAYRAM_DB_MODE` | `internal` | `internal` (containerized) or `external` (needs `DB_NAME`, `DB_USER`, `DB_PASSWORD`; `DB_HOST`/`DB_PORT` default `localhost`/`5432`) |
 | `PAYRAM_SSL_MODE` | `none` | `none`, `letsencrypt` (needs `DOMAIN_NAME` + `LE_EMAIL`), or `custom` (certs already in place) |
-| `PAYRAM_HOST_PORT` | `80` (auto-fallback) | Host port publishing HTTP; agent auto-picks first free of 80/8080/8081/8088/8888 |
+| `PAYRAM_HOST_PORT` | `80` | HTTP host port. Bundled nginx proxies everything inside the container - 80 (+443 with TLS) are the only ports needed. Fails fast if busy |
 | `PAYRAM_NONINTERACTIVE` | auto (no TTY) | Set `1` to force headless prompts even with a TTY |
 | `PAYRAM_NODE_MODE` | `docker` | JS runtime: `docker` or `host` |
 | `PAYRAM_NODE_DOCKER_IMAGE` | `node:20-bullseye-slim` | Docker image used for JS scripts |
@@ -212,17 +213,22 @@ The one-step flow does:
 5. `ensure-config` for local frontend/backend settings.
 6. Wallet flow (MVF: **USDC on Base**):
 	- Default: EVM smart-contract wallet deploy (blocking, guided gas funding).
-	  The master (deployer) wallet is generated locally and is **ops-only**;
-	  once all chains are set up, back it up offline and remove it from the
-	  host. On **mainnet** the sweep destination must be a human-provided cold
+	  The master (deployer) wallet is generated locally and is **ops-only** -
+	  but KEEP it: it's needed to deploy on more chains and to change the
+	  cold-wallet config on-chain. Back it up offline FIRST; remove it from
+	  the host only once ALL chains are deployed and the cold-wallet config is
+	  final. On **mainnet** the sweep destination must be a human-provided cold
 	  address (`PAYRAM_FUND_COLLECTOR`) — never a silent default.
-	- **Fund on either chain (mainnet)**: the human sends ETH to ONE address -
-	  ~\$5 on the **Base** network (easiest) or ~\$30 on Ethereum (higher fees).
-	  Same address on both; the flow watches both chains and deploys where the
-	  funds land - the human never has to understand networks. Explicit
+	- **Fund on either chain (mainnet)**: the human sends **~\$10 of ETH** to
+	  ONE address - Ethereum network or Base network, both work (same address;
+	  pick Base when unsure). The flow watches both chains and deploys where
+	  the funds land - the human never has to understand networks. Explicit
 	  `PAYRAM_BLOCKCHAIN_CODE=ETH/POLYGON` or `PAYRAM_ETH_RPC_URL` pins a
 	  single chain instead.
 	  Re-runs are idempotent: an already-linked EVM wallet skips the deploy.
+	- **Testnet note**: test tokens are free but faucets often have
+	  requirements (account, mainnet balance, social post). If they block you,
+	  mainnet with ~\$10 of ETH is usually the faster path.
 	- `--ensure-wallet`: BTC-first fast lane instead - **BTC XPUB** starter
 	  wallet (instant, zero gas); the SCW is then attempted after the link.
 	- `--skip-scw`: no gas at all - BTC-only fast lane.
@@ -345,7 +351,7 @@ admin/setup APIs; **API key** for merchant payment APIs and the MCP.
 
 ## Agent automation tips
 
-- Always set `PAYRAM_EMAIL`, `PAYRAM_PASSWORD`, and `PAYRAM_CUSTOMER_ID` for fully non-interactive runs.
+- Credentials are optional: first `setup` auto-creates root credentials (saved 600 to `.payraminfo/root-credentials.env`; change in dashboard) and later `signin` re-reads them. Set `PAYRAM_EMAIL`/`PAYRAM_PASSWORD` only to pin your own.
 - Use `PAYRAM_WALLET_CHOICE=1` and `PAYRAM_WALLET_QUIET=1` to avoid wallet prompts.
 - For SCW, set `PAYRAM_SCW_MIN_BALANCE_ETH` to a known safe threshold if your RPC has delayed balance reporting.
 - When using Docker node runtime, ensure Docker is running and has access to host networking.

--- a/setup_payram_agents.sh
+++ b/setup_payram_agents.sh
@@ -57,7 +57,7 @@ Env vars:
 	Headless fresh-install knobs (no TTY needed; every prompt resolves from env):
 	PAYRAM_DB_MODE (internal|external; default internal. external needs DB_NAME, DB_USER, DB_PASSWORD [+DB_HOST, DB_PORT])
 	PAYRAM_SSL_MODE (none|letsencrypt|custom; default none. letsencrypt needs DOMAIN_NAME + LE_EMAIL)
-	PAYRAM_HOST_PORT (HTTP host port; default 80, auto-falls back to first free of 8080/8081/8088/8888)
+	PAYRAM_HOST_PORT (HTTP host port; default 80 - the bundled nginx proxies everything inside the container. Fails fast if 80 is busy)
 	PAYRAM_NONINTERACTIVE=1 (force headless even with a TTY)
 	PAYRAM_OPERATOR_BTC_FEE_COLLECTOR, PAYRAM_OPERATOR_EVM_FEE_COLLECTOR
 	PAYRAM_OPERATOR_FEE_BPS (default 100 = 1%, max 1500)
@@ -136,24 +136,6 @@ run_as_root() {
 	fi
 }
 
-# Pick the host port a headless install publishes HTTP on: 80 when free, else
-# the first free fallback. Deterministic - same machine state, same answer.
-# The installer re-validates whatever we pick (PAYRAM_HOST_PORT).
-pick_free_http_port() {
-	local p
-	for p in 80 8080 8081 8088 8888; do
-		# bash /dev/tcp probe: connect succeeds -> something is listening.
-		if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then
-			echo "$p"
-			return 0
-		fi
-		exec 3>&- 3<&- 2>/dev/null || true
-	done
-	# Every candidate is taken - surface a clear, fixable error.
-	echo "80"
-	return 0
-}
-
 wait_for_api() {
 	local max_tries=60
 	local wait_secs=2
@@ -193,6 +175,7 @@ PAYRAM_INFO_DIR="${PAYRAM_INFO_DIR:-}"
 PAYRAM_CORE_DIR="${PAYRAM_CORE_DIR:-}"
 PAYRAM_API_URL="${PAYRAM_API_URL:-}"
 TOKEN_FILE=""
+CREDENTIALS_FILE=""
 PAYRAM_NODE_MODE="${PAYRAM_NODE_MODE:-}"
 PAYRAM_NODE_DOCKER_IMAGE="${PAYRAM_NODE_DOCKER_IMAGE:-}"
 NODE_MODE_RESOLVED=""
@@ -661,9 +644,9 @@ troubleshoot() {
 			echo "Deployer wallet has insufficient ETH for gas (this is ops fuel, not savings)."
 			echo "  [90%] The deployer address was not funded (or not enough)."
 			if [[ "${PAYRAM_NETWORK:-testnet}" == "mainnet" && "${PAYRAM_SCW_CHAIN_DEFAULTED:-0}" == "1" ]]; then
-				echo "        -> send ETH to: ${PAYRAM_DEPLOYER_ADDRESS:-<deployer>}"
-				echo "           ~\$5 on the BASE network (easiest), or ~\$30 on Ethereum -"
-				echo "           same address on both; we detect where it lands."
+				echo "        -> send ~\$10 of ETH to: ${PAYRAM_DEPLOYER_ADDRESS:-<deployer>}"
+				echo "           Ethereum or Base network - both work, same address; we detect"
+				echo "           where it lands. Pick Base if your wallet asks and you're unsure."
 			else
 				echo "        -> send >= ${PAYRAM_SCW_MIN_BALANCE_ETH:-0.01} ETH to: ${PAYRAM_DEPLOYER_ADDRESS:-<deployer>}"
 			fi
@@ -903,6 +886,40 @@ cmd_status() {
 	fi
 }
 
+# Zero-input credentials: when PAYRAM_EMAIL/PAYRAM_PASSWORD are not provided,
+# generate them (random password, local default email) and persist 600 next to
+# the auth tokens - both are changeable from the dashboard later, so this is
+# config-pushed-to-the-end, not a security downgrade. Later runs (signin)
+# re-read the same file, so nothing has to be remembered or exported.
+load_or_create_root_credentials() {
+	if [[ -n "${PAYRAM_EMAIL:-}" && -n "${PAYRAM_PASSWORD:-}" ]]; then
+		return 0
+	fi
+	if [[ -n "$CREDENTIALS_FILE" && -f "$CREDENTIALS_FILE" ]]; then
+		# shellcheck source=/dev/null
+		source "$CREDENTIALS_FILE"
+		export PAYRAM_EMAIL PAYRAM_PASSWORD
+		[[ -n "${PAYRAM_EMAIL:-}" && -n "${PAYRAM_PASSWORD:-}" ]] && return 0
+	fi
+	export PAYRAM_EMAIL="${PAYRAM_EMAIL:-admin@payram.local}"
+	if [[ -z "${PAYRAM_PASSWORD:-}" ]]; then
+		if command -v openssl >/dev/null 2>&1; then
+			PAYRAM_PASSWORD="$(openssl rand -base64 18 | tr -d '/+=' | cut -c1-16)"
+		else
+			PAYRAM_PASSWORD="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' | cut -c1-16)"
+		fi
+		export PAYRAM_PASSWORD
+	fi
+	if [[ -n "$CREDENTIALS_FILE" ]]; then
+		mkdir -p "$(dirname "$CREDENTIALS_FILE")"
+		printf 'PAYRAM_EMAIL="%s"\nPAYRAM_PASSWORD="%s"\n' "$PAYRAM_EMAIL" "$PAYRAM_PASSWORD" > "$CREDENTIALS_FILE"
+		chmod 600 "$CREDENTIALS_FILE"
+	fi
+	echo "Root credentials auto-created (change anytime in the dashboard):"
+	echo "  email: $PAYRAM_EMAIL"
+	echo "  saved to: ${CREDENTIALS_FILE:-<not persisted>} (password inside, mode 600)"
+}
+
 cmd_setup() {
 	local res body code
 	res=$(curl -s -w "\n%{http_code}" "${PAYRAM_API_URL}/api/v1/member/root/exist")
@@ -917,19 +934,9 @@ cmd_setup() {
 		echo "Root user already exists. Use 'signin' then 'create-payment-link'."
 		return 0
 	fi
-	local email="${PAYRAM_EMAIL:-}"
-	local password="${PAYRAM_PASSWORD:-}"
-	if [[ ( -z "$email" || -z "$password" ) && ! -t 0 ]]; then
-		troubleshoot auth-env
-		return 1
-	fi
-	if [[ -z "$email" ]]; then
-		read -p "Email for root user: " email
-	fi
-	if [[ -z "$password" ]]; then
-		read -s -p "Password: " password
-		echo
-	fi
+	load_or_create_root_credentials
+	local email="$PAYRAM_EMAIL"
+	local password="$PAYRAM_PASSWORD"
 	res=$(curl -s -w "\n%{http_code}" -X POST "${PAYRAM_API_URL}/api/v1/signup" \
 		-H "Content-Type: application/json" -d "{\"email\":\"$email\",\"password\":\"$password\"}")
 	body=$(echo "$res" | sed '$d')
@@ -962,6 +969,14 @@ cmd_setup() {
 cmd_signin() {
 	local email="${PAYRAM_EMAIL:-}"
 	local password="${PAYRAM_PASSWORD:-}"
+	# Auto-created credentials from a previous setup run live next to the
+	# tokens - re-use them so signin needs no env vars either.
+	if [[ ( -z "$email" || -z "$password" ) && -n "$CREDENTIALS_FILE" && -f "$CREDENTIALS_FILE" ]]; then
+		# shellcheck source=/dev/null
+		source "$CREDENTIALS_FILE"
+		email="${email:-${PAYRAM_EMAIL:-}}"
+		password="${password:-${PAYRAM_PASSWORD:-}}"
+	fi
 	if [[ ( -z "$email" || -z "$password" ) && ! -t 0 ]]; then
 		troubleshoot auth-env
 		return 1
@@ -1080,8 +1095,8 @@ get_eth_deployer_address() {
 check_eth_balance_any() {
 	local script_dir="$SCRIPT_DIR/scripts"
 	ensure_node_deps "$script_dir" || return 1
-	PAYRAM_SCW_MIN_BASE="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_BASE:-0.002}}" \
-	PAYRAM_SCW_MIN_ETHL1="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_ETHL1:-0.01}}" \
+	PAYRAM_SCW_MIN_BASE="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_BASE:-0.0015}}" \
+	PAYRAM_SCW_MIN_ETHL1="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_ETHL1:-0.0025}}" \
 	run_node "$script_dir" -e "
 		const { ethers } = require('ethers');
 		const addr = process.env.PAYRAM_DEPLOYER_ADDRESS;
@@ -1536,16 +1551,14 @@ cmd_deploy_scw_flow() {
 		echo ""
 		echo "--- One step needs you: add a little ETH (this pays the network fees) ---"
 		echo ""
-		echo "Send ETH to this address:"
+		echo "Send about \$10 worth of ETH to this address:"
 		echo ""
 		echo "  $deployer"
 		echo ""
-		echo "  - Easiest: about \$5 of ETH on the BASE network."
-		echo "    (If your wallet or exchange asks which network, pick 'Base'.)"
-		echo "  - Sending on the Ethereum network works too, but its fees are higher -"
-		echo "    send about \$30 there instead."
-		echo "  - Same address on both. I'll detect where the funds land and continue"
-		echo "    automatically. This is resumable - re-running continues the wait."
+		echo "  - Ethereum network or Base network - BOTH work, it's the same address."
+		echo "    (If your wallet or exchange asks which network, pick 'Base' when unsure.)"
+		echo "  - I'll detect where the funds land and continue automatically."
+		echo "  - This is resumable - re-running continues the wait."
 		echo "--------------------------------------------------------------------------"
 		while true; do
 			local status chain balances res
@@ -2201,6 +2214,9 @@ flow_main() {
 			echo "Choose network:"
 			echo "  1) mainnet - real payments (default)"
 			echo "  2) testnet - try everything first with free test coins"
+			echo "     Heads-up: test tokens are free but often a hassle to get - faucets"
+			echo "     usually want an account, a mainnet balance, or a social post."
+			echo "     With ~\$10 of real ETH, mainnet is often the faster path."
 			read -p "Selection [1]: " net_choice
 			net_choice="${net_choice:-1}"
 			if [[ "$net_choice" == "2" ]]; then
@@ -2211,6 +2227,10 @@ flow_main() {
 		else
 			network_mode="mainnet"
 		fi
+	fi
+	if [[ "$network_mode" == "testnet" ]]; then
+		log "Testnet mode. Note: faucets often have requirements (account, mainnet balance,"
+		log "social post) - if they block you, mainnet with ~\$10 of ETH is the faster path."
 	fi
 
 	export PAYRAM_NODE_MODE="$node_mode"
@@ -2236,18 +2256,18 @@ flow_main() {
 	elif ! is_payram_running; then
 		# A FRESH install delegates to setup_payram.sh and ALWAYS runs it with
 		# zero questions: every choice resolves from PAYRAM_* env knobs with
-		# deterministic defaults (internal DB, no SSL, port 80 or first free
-		# fallback). Config-comes-later UX: SSL, ports, and DB can all be
-		# changed once the gateway works - the goal here is the payment link.
-		# Humans who want the full interactive installer run it directly:
-		#   sudo ./setup_payram.sh
+		# deterministic defaults (internal DB, no SSL, port 80). The bundled
+		# nginx inside the container reverse-proxies everything - 80 (and 443
+		# with TLS) are the only ports PayRam needs. If 80 is busy the
+		# installer fails fast with the listener + the PAYRAM_HOST_PORT
+		# override; we don't silently pick another port (links on :8080
+		# surprise people). Config-comes-later UX: SSL, ports, and DB can all
+		# be changed once the gateway works - the goal here is the payment
+		# link. Full interactive installer: sudo ./setup_payram.sh
 		export PAYRAM_NONINTERACTIVE=1
 		export PAYRAM_DB_MODE="${PAYRAM_DB_MODE:-internal}"
 		export PAYRAM_SSL_MODE="${PAYRAM_SSL_MODE:-none}"
-		if [[ -z "${PAYRAM_HOST_PORT:-}" ]]; then
-			export PAYRAM_HOST_PORT="$(pick_free_http_port)"
-		fi
-		log "Install defaults: DB=${PAYRAM_DB_MODE} SSL=${PAYRAM_SSL_MODE} port=${PAYRAM_HOST_PORT} (${network_mode})"
+		log "Install defaults: DB=${PAYRAM_DB_MODE} SSL=${PAYRAM_SSL_MODE} port=${PAYRAM_HOST_PORT:-80} (${network_mode})"
 		log "All of this is changeable later - SSL included. Overrides: PAYRAM_DB_MODE / PAYRAM_SSL_MODE / PAYRAM_HOST_PORT."
 		log "Installing/starting PayRam (${network_mode})..."
 		local install_rc=0
@@ -2381,7 +2401,9 @@ flow_main() {
 		echo "  - More chains later:  PAYRAM_BLOCKCHAIN_CODE=ETH $0 deploy-scw   (POLYGON likewise)"
 		echo "  - Add BTC payments:  $0 ensure-wallet"
 		echo "  - Master wallet is local + ops-only ($PAYRAM_INFO_DIR/headless-wallet-secret.txt)."
-		echo "    Once all chains are set up: back it up offline, then remove it from this host."
+		echo "    KEEP it for now - it's needed to deploy on more chains and to change the"
+		echo "    cold-wallet config on-chain. Back it up offline FIRST; only remove it from"
+		echo "    this host once ALL chains are deployed and the cold-wallet config is final."
 	else
 		echo "  - USDC/EVM payments: NOT yet enabled. Fund the deployer with gas and run:"
 		echo "    $0 deploy-scw-flow"
@@ -2468,6 +2490,7 @@ main() {
 	TOKEN_FILE="${PAYRAM_INFO_DIR}/headless-tokens.env"
 	SCW_STATE_FILE="${PAYRAM_INFO_DIR}/scw-state.env"
 	API_KEY_FILE="${PAYRAM_INFO_DIR}/merchant-api-key.env"
+	CREDENTIALS_FILE="${PAYRAM_INFO_DIR}/root-credentials.env"
 	PAYRAM_NODE_MODE="$PAYRAM_NODE_MODE"
 	PAYRAM_NODE_DOCKER_IMAGE="$PAYRAM_NODE_DOCKER_IMAGE"
 


### PR DESCRIPTION
UX polish per review of the agent flow:

1. **Zero-input auth** — first setup auto-creates root credentials (saved 600 to `.payraminfo/root-credentials.env`, changeable in dashboard); signin re-reads them. The flow now needs literally no env vars.
2. **Port 80 only** — removed the 8080-fallback; bundled nginx in the container proxies everything, so 80 (+443 TLS) are the only ports. Busy 80 fails fast with guidance.
3. **$10 either-chain funding** — message simplified ('~$10 of ETH, Ethereum or Base, same address, pick Base if unsure'); per-chain minimums (0.0015/0.0025) ensure $10 clears both.
4. **Testnet warning** — faucets are gated more often than people expect; tells users mainnet + $10 is often faster.
5. **Master wallet** — keep until ALL chains deployed + cold config final (needed for future deploys and on-chain cold-wallet changes); back up offline before any removal.

Unit-tested credentials helper (create/reload/env-wins); bash -n clean.