### PR TITLE
fix: V2 factory ABI support in SCW deploy; try-on-any-funds balance check

### DIFF
--- a/scripts/deploy-scw-eth.js
+++ b/scripts/deploy-scw-eth.js
@@ -102,10 +102,38 @@ async function main() {
   // 3) Salt bytes32 (same idea as frontend: keccak256 of random)
   const salt = ethers.keccak256(ethers.toUtf8Bytes(`${Date.now()}-${Math.random().toString(36).slice(2)}`));
 
-  // 4) Call createFundSweeperContract(salt, fundCollector)
+  // 4) Call createFundSweeperContract - the factory has two generations:
+  //    V1: createFundSweeperContract(bytes32 salt, address fundCollector)
+  //    V2: createFundSweeperContract(address fundCollector, bytes32 salt,
+  //          address operatorFeeAdmin, address operatorFeeCollector, uint16 bps)
+  //    NOTE the argument ORDER FLIPS between them (V2 matches the Tron factory).
+  //    The backend serves the ABI of whichever factory is deployed, so detect
+  //    which overload exists and call that one. Merchant deploys pass
+  //    (deployer, deployer, 0) for the operator-fee args - bps=0 means the
+  //    addresses are never used at sweep time (mirrors the dashboard frontend).
   const contract = new ethers.Contract(factoryAddress, abi, signer);
-  console.log('Sending deploy tx (createFundSweeperContract)...');
-  const tx = await contract.createFundSweeperContract(salt, fundCollector, { gasLimit: 500000n });
+  const createFragments = abi.filter(
+    (f) => f && f.type === 'function' && f.name === 'createFundSweeperContract'
+  );
+  const hasV2 = createFragments.some((f) => (f.inputs || []).length === 5);
+  const hasV1 = createFragments.some((f) => (f.inputs || []).length === 2);
+  if (!hasV1 && !hasV2) {
+    console.error(
+      'Factory ABI has no createFundSweeperContract with 2 or 5 args - the backend served an unexpected ABI.'
+    );
+    process.exit(1);
+  }
+  console.log(`Sending deploy tx (createFundSweeperContract, ${hasV2 ? 'V2 5-arg' : 'V1 2-arg'})...`);
+  let tx;
+  if (hasV2) {
+    tx = await contract['createFundSweeperContract(address,bytes32,address,address,uint16)'](
+      fundCollector, salt, deployerAddress, deployerAddress, 0, { gasLimit: 900000n }
+    );
+  } else {
+    tx = await contract['createFundSweeperContract(bytes32,address)'](
+      salt, fundCollector, { gasLimit: 500000n }
+    );
+  }
   console.log('Tx sent, waiting for confirmation:', tx.hash);
   const receipt = await tx.wait();
   const txHash = receipt.hash;

--- a/setup_payram_agents.sh
+++ b/setup_payram_agents.sh
@@ -648,7 +648,8 @@ troubleshoot() {
 				echo "           Ethereum or Base network - both work, same address; we detect"
 				echo "           where it lands. Pick Base if your wallet asks and you're unsure."
 			else
-				echo "        -> send >= ${PAYRAM_SCW_MIN_BALANCE_ETH:-0.01} ETH to: ${PAYRAM_DEPLOYER_ADDRESS:-<deployer>}"
+				echo "        -> send ETH (any amount lets the deploy try; ~\$10 is comfortable)"
+				echo "           to: ${PAYRAM_DEPLOYER_ADDRESS:-<deployer>}"
 			fi
 			if [[ "${PAYRAM_NETWORK:-testnet}" != "mainnet" ]]; then
 				echo "        -> testnet faucets:"
@@ -1095,8 +1096,8 @@ get_eth_deployer_address() {
 check_eth_balance_any() {
 	local script_dir="$SCRIPT_DIR/scripts"
 	ensure_node_deps "$script_dir" || return 1
-	PAYRAM_SCW_MIN_BASE="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_BASE:-0.0015}}" \
-	PAYRAM_SCW_MIN_ETHL1="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_ETHL1:-0.0025}}" \
+	PAYRAM_SCW_MIN_BASE="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_BASE:-0}}" \
+	PAYRAM_SCW_MIN_ETHL1="${PAYRAM_SCW_MIN_BALANCE_ETH:-${PAYRAM_SCW_MIN_ETHL1:-0}}" \
 	run_node "$script_dir" -e "
 		const { ethers } = require('ethers');
 		const addr = process.env.PAYRAM_DEPLOYER_ADDRESS;
@@ -1111,7 +1112,8 @@ check_eth_balance_any() {
 					const bal = await new ethers.JsonRpcProvider(rpc).getBalance(addr);
 					allFailed = false;
 					summary.push(chain.toLowerCase() + '=' + ethers.formatEther(bal));
-					if (!anyOk && bal >= ethers.parseEther(min)) { anyOk = true; winner = chain; }
+					const ok = min === '0' ? bal > 0n : bal >= ethers.parseEther(min);
+					if (!anyOk && ok) { anyOk = true; winner = chain; }
 				} catch (e) { summary.push(chain.toLowerCase() + '=?'); }
 			}
 			if (allFailed) process.exit(1);
@@ -1125,15 +1127,18 @@ check_eth_balance_any() {
 check_eth_balance() {
 	local script_dir="$SCRIPT_DIR/scripts"
 	ensure_node_deps "$script_dir" || return 1
-	PAYRAM_SCW_MIN_BALANCE_ETH="${PAYRAM_SCW_MIN_BALANCE_ETH:-0.01}" run_node "$script_dir" -e "
+	# Any balance > 0 is a green light: we don't gate on a guessed gas number -
+	# the deploy simply tries, and an out-of-gas failure is resumable. Setting
+	# PAYRAM_SCW_MIN_BALANCE_ETH explicitly restores a hard threshold.
+	PAYRAM_SCW_MIN_BALANCE_ETH="${PAYRAM_SCW_MIN_BALANCE_ETH:-0}" run_node "$script_dir" -e "
 		const { ethers } = require('ethers');
 		const rpc = process.env.PAYRAM_ETH_RPC_URL;
 		const addr = process.env.PAYRAM_DEPLOYER_ADDRESS;
-		const min = process.env.PAYRAM_SCW_MIN_BALANCE_ETH || '0.01';
+		const min = process.env.PAYRAM_SCW_MIN_BALANCE_ETH || '0';
 		const provider = new ethers.JsonRpcProvider(rpc);
 		(async () => {
 			const bal = await provider.getBalance(addr);
-			const ok = bal >= ethers.parseEther(min);
+			const ok = min === '0' ? bal > 0n : bal >= ethers.parseEther(min);
 			console.log(ok ? 'OK' : 'WAIT');
 			console.log(ethers.formatEther(bal));
 		})().catch(() => process.exit(1));
@@ -1532,16 +1537,9 @@ cmd_deploy_scw_flow() {
 	fi
 	export PAYRAM_DEPLOYER_ADDRESS="$deployer"
 
-	# Single-chain threshold default. Skipped for the dual-watch path, which
-	# carries per-chain minimums (Base ~\$5 vs Ethereum L1 ~\$30) inside
-	# check_eth_balance_any - a flat 0.02 here would break the \$5-on-Base UX.
-	if [[ -z "${PAYRAM_SCW_MIN_BALANCE_ETH:-}" && -z "$dual_watch" ]]; then
-		if [[ "${PAYRAM_NETWORK:-}" == "mainnet" ]]; then
-			PAYRAM_SCW_MIN_BALANCE_ETH="0.02"
-		else
-			PAYRAM_SCW_MIN_BALANCE_ETH="0.01"
-		fi
-	fi
+	# No threshold gating by default: any balance > 0 lets the deploy try
+	# (out-of-gas just fails and resumes). PAYRAM_SCW_MIN_BALANCE_ETH, when
+	# explicitly set, restores a hard gate in both checkers.
 
 	local attempts=0
 	local max_attempts="${PAYRAM_SCW_FUND_MAX_ATTEMPTS:-60}"
@@ -1599,7 +1597,12 @@ cmd_deploy_scw_flow() {
 	else
 		echo ""
 		echo "--- Gas refill needed (ops fuel for the deploy + future sweeps, not savings) ---"
-		echo "Send >= ${PAYRAM_SCW_MIN_BALANCE_ETH} ETH to the deployer address:"
+		if [[ -n "${PAYRAM_SCW_MIN_BALANCE_ETH:-}" && "${PAYRAM_SCW_MIN_BALANCE_ETH}" != "0" ]]; then
+			echo "Send >= ${PAYRAM_SCW_MIN_BALANCE_ETH} ETH to the deployer address:"
+		else
+			echo "Send ETH for gas to the deployer address (any amount lets the deploy try;"
+			echo "~\$10 worth is comfortably enough - too little just fails and resumes):"
+		fi
 		echo ""
 		echo "  $deployer"
 		echo ""
@@ -1631,7 +1634,11 @@ cmd_deploy_scw_flow() {
 				break
 			fi
 			if [[ -t 0 ]]; then
-				echo "Balance ${balance} ETH is below ${PAYRAM_SCW_MIN_BALANCE_ETH}. Add funds and press Enter to recheck."
+				if [[ -n "${PAYRAM_SCW_MIN_BALANCE_ETH:-}" && "${PAYRAM_SCW_MIN_BALANCE_ETH}" != "0" ]]; then
+					echo "Balance ${balance} ETH is below ${PAYRAM_SCW_MIN_BALANCE_ETH}. Add funds and press Enter to recheck."
+				else
+					echo "No funds detected yet (balance ${balance} ETH). Add ETH and press Enter to recheck."
+				fi
 				read -r _
 			else
 				if [[ $attempts -ge $max_attempts ]]; then


### PR DESCRIPTION
Fixes the two issues from the real install run:

1. **`no matching fragment` deploy error** — the script called the V1 2-arg `createFundSweeperContract(salt, fundCollector)`, but the backend serves the **V2 factory** whose ABI exposes the 5-arg overload `(fundCollector, salt, opFeeAdmin, opFeeCollector, bps)` (arg order flips between generations — V2 matches Tron). Now detects which overload the served ABI has and calls it; merchant deploys pass `(deployer, deployer, 0)` mirroring the dashboard frontend. Clear error if neither overload exists.
2. **Balance gate** — per review: any balance > 0 proceeds (deploy just tries; out-of-gas fails resumable). 0 still waits. Explicit `PAYRAM_SCW_MIN_BALANCE_ETH` restores a hard gate.

Verified: bash -n, node --check, unit tests (overload detection; 0/any/explicit-gate logic). Real-deploy retest needed on the same box that hit the error.