### PR TITLE
fix: version-spanning core API calls — project listing + SCW registration

### DIFF
--- a/scripts/deploy-scw-eth.js
+++ b/scripts/deploy-scw-eth.js
@@ -140,15 +140,31 @@ async function main() {
 
   console.log('Deploy tx confirmed:', txHash);
 
-  // 5) Register with backend
-  const registerUrl = `${PAYRAM_API_URL}/api/v1/wallets/deposit/scw/blockchains_contract/${factoryId}`;
-  const registerRes = await fetch(registerUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ name: PAYRAM_SCW_NAME, transactionHash: txHash }),
-  });
-  if (!registerRes.ok) {
-    console.error('Failed to register SCW:', registerRes.status, await registerRes.text());
+  // 5) Register with backend. The route moved across core versions:
+  //    current core:  POST /api/v1/project/{projectID}/wallets/deposit/scw/blockchains_contract/{id}
+  //    older images:  POST /api/v1/wallets/deposit/scw/blockchains_contract/{id}
+  //    Body ({name, transactionHash}) is the same in both. Try the
+  //    project-scoped path when we know the project, fall back to legacy on
+  //    404/405 so the script works against whichever image is deployed.
+  const projectId = (process.env.PAYRAM_PROJECT_ID || '').trim();
+  const registerBody = JSON.stringify({ name: PAYRAM_SCW_NAME, transactionHash: txHash });
+  const registerHeaders = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+  const candidates = [];
+  if (projectId) {
+    candidates.push(`${PAYRAM_API_URL}/api/v1/project/${projectId}/wallets/deposit/scw/blockchains_contract/${factoryId}`);
+  }
+  candidates.push(`${PAYRAM_API_URL}/api/v1/wallets/deposit/scw/blockchains_contract/${factoryId}`);
+
+  let registerRes;
+  for (const url of candidates) {
+    registerRes = await fetch(url, { method: 'POST', headers: registerHeaders, body: registerBody });
+    if (registerRes.ok) break;
+    if (registerRes.status !== 404 && registerRes.status !== 405) break; // real error - don't retry blindly
+    console.log(`Register endpoint not found at ${url} - trying fallback...`);
+  }
+  if (!registerRes || !registerRes.ok) {
+    console.error('Failed to register SCW:', registerRes && registerRes.status, registerRes ? await registerRes.text() : '');
+    console.error('The deploy tx succeeded (' + txHash + ') - registration is retryable without re-paying gas.');
     process.exit(1);
   }
   const result = await registerRes.json();

--- a/setup_payram_agents.sh
+++ b/setup_payram_agents.sh
@@ -295,12 +295,23 @@ parse_auth_tokens() {
 	MEMBER_EMAIL=$(echo "$body" | grep -o '"email":"[^"]*"' | tail -1 | cut -d'"' -f4)
 }
 
+# List projects, spanning core versions: older images serve
+# /external-platform/all; current core serves /external-platform/details.
+# Try the new path first, fall back to the legacy one. Sets HTTP_CODE/HTTP_BODY.
+api_list_projects() {
+	local res
+	res=$(api GET "/api/v1/external-platform/details" "" true)
+	parse_response "$res"
+	if [[ "$HTTP_CODE" == "404" || "$HTTP_CODE" == "405" ]]; then
+		res=$(api GET "/api/v1/external-platform/all" "" true)
+		parse_response "$res"
+	fi
+}
+
 # First project id - the script's "current project" policy, in ONE place.
 # Echoes the id; guidance goes to stderr so $(capture) stays clean.
 get_first_project_id() {
-	local res
-	res=$(api GET "/api/v1/external-platform/all" "" true)
-	parse_response "$res"
+	api_list_projects
 	if [[ "$HTTP_CODE" != "200" ]]; then
 		echo "Failed to list projects: $HTTP_BODY" >&2
 		return 1
@@ -744,7 +755,7 @@ run_node() {
 			api_override="${api_override/127.0.0.1/host.docker.internal}"
 			env_flags+=("-e" "PAYRAM_API_URL=${api_override}")
 		fi
-		for var in PAYRAM_API_URL PAYRAM_ACCESS_TOKEN PAYRAM_MNEMONIC_FILE PAYRAM_ETH_RPC_URL PAYRAM_FUND_COLLECTOR PAYRAM_SCW_NAME PAYRAM_BLOCKCHAIN_CODE PAYRAM_MNEMONIC PAYRAM_DEPLOYER_ADDRESS PAYRAM_SCW_MIN_BALANCE_ETH; do
+		for var in PAYRAM_API_URL PAYRAM_ACCESS_TOKEN PAYRAM_MNEMONIC_FILE PAYRAM_ETH_RPC_URL PAYRAM_FUND_COLLECTOR PAYRAM_SCW_NAME PAYRAM_BLOCKCHAIN_CODE PAYRAM_MNEMONIC PAYRAM_DEPLOYER_ADDRESS PAYRAM_SCW_MIN_BALANCE_ETH PAYRAM_PROJECT_ID; do
 			if [[ -n "${!var:-}" ]]; then
 				if [[ "$var" != "PAYRAM_API_URL" || -z "$api_override" ]]; then
 					env_flags+=("-e" "$var")
@@ -842,9 +853,9 @@ refresh_token() {
 ensure_token() {
 	load_tokens
 	if [[ -n "${ACCESS_TOKEN:-}" ]]; then
-		local check
-		check=$(api GET "/api/v1/external-platform/all" "" true)
-		parse_response "$check"
+		# Version-spanning auth probe (details on current core, /all on older
+		# images) - a 404 here must never be mistaken for "not signed in".
+		api_list_projects
 		if [[ "$HTTP_CODE" == "200" ]]; then
 			return 0
 		fi
@@ -1431,6 +1442,13 @@ cmd_deploy_scw() {
 	export PAYRAM_API_URL
 	export PAYRAM_ACCESS_TOKEN="$ACCESS_TOKEN"
 	export PAYRAM_MNEMONIC_FILE="${PAYRAM_INFO_DIR}/headless-wallet-secret.txt"
+	# Current core registers the SCW under the project; older images use the
+	# legacy unscoped route. Pass the project id so the deploy script can try
+	# the project-scoped path first (it falls back on 404). Best-effort.
+	if [[ -z "${PAYRAM_PROJECT_ID:-}" ]]; then
+		PAYRAM_PROJECT_ID="$(get_first_project_id 2>/dev/null || true)"
+	fi
+	[[ -n "${PAYRAM_PROJECT_ID:-}" ]] && export PAYRAM_PROJECT_ID
 	[[ -n "${PAYRAM_ETH_RPC_URL:-}" ]] && export PAYRAM_ETH_RPC_URL
 	if [[ -n "${PAYRAM_FUND_COLLECTOR:-}" ]] && [[ "$PAYRAM_FUND_COLLECTOR" =~ ^0x[a-fA-F0-9]{40}$ ]]; then
 		export PAYRAM_FUND_COLLECTOR


### PR DESCRIPTION
Full script-vs-backend audit (26 method+path pairs vs payram-core origin/main + released CSV). Two drifts, both fixed version-spanning since the deployed image version is unknown:

1. **`GET /external-platform/all` is gone on current core** — and it doubled as the auth probe in `ensure_token`, so on a new image a valid session would read as signed-out. `api_list_projects` tries `/details` → falls back to `/all`.
2. **SCW registration moved to the project-scoped route** (operator-fees work). Deploy script tries `/project/{id}/...` first (project id passed via env + docker whitelist), falls back to legacy on 404/405. Body unchanged. A registration failure now states the deploy tx succeeded and is retryable without re-paying gas.

Everything else verified OK (auth, blockchains, wallets, configuration, external-platform create/payment/api-key, operator, factory fetch).