### PR TITLE
revert: keep setup_payram.sh untouched — agent-only scope

### DIFF
--- a/docs/PAYRAM_HEADLESS_AGENT.md
+++ b/docs/PAYRAM_HEADLESS_AGENT.md
@@ -74,14 +74,13 @@ with the exact fix command, and a non-zero exit.
   running container); default `http://localhost` (the installer publishes
   `80:80`). Override with `PAYRAM_API_URL` only if you know better.
 - Docker required if `PAYRAM_NODE_MODE=docker` (default) for JS tooling.
-- A **fresh install is fully headless and zero-question** (TTY or not): every
-  choice resolves from env knobs with deterministic defaults: containerized DB,
-  no SSL (add later), HTTP on **port 80** — the bundled nginx inside the
-  container reverse-proxies everything, so 80 (and 443 with TLS) are the only
-  ports PayRam needs. Override with `PAYRAM_DB_MODE`, `PAYRAM_SSL_MODE`,
-  `PAYRAM_HOST_PORT`. Anything ambiguous (external DB without credentials,
-  letsencrypt without `DOMAIN_NAME`/`LE_EMAIL`, port 80 busy, low disk)
-  **fails fast naming the exact env var to set** — it never hangs on a prompt.
+- A **fresh install needs a terminal once** — `setup_payram.sh` (the working
+  installer, unmodified) asks its one-time DB/SSL/port questions interactively.
+  Defaults are fine to start: containerized DB, no SSL (add later), HTTP on
+  **port 80** (the bundled nginx inside the container reverse-proxies
+  everything, so 80 — plus 443 with TLS — are the only ports PayRam needs).
+  **Everything after the install is fully headless.** Without a TTY the agent
+  flow fails fast with directions rather than letting prompts hang.
 
 ---
 
@@ -127,11 +126,6 @@ Set these for non-interactive or scripted runs. For agents, prefer env-driven, n
 | `PAYRAM_CUSTOMER_ID` | from signin | Usually from token file after signin |
 | `PAYRAM_FRONTEND_URL` | `http://localhost` | Used by ensure-config (local) |
 | `PAYRAM_NETWORK` | `mainnet` | One-step flow network selection (`mainnet` default - real payments; `testnet` to try with free coins) |
-| **headless fresh install** | | |
-| `PAYRAM_DB_MODE` | `internal` | `internal` (containerized) or `external` (needs `DB_NAME`, `DB_USER`, `DB_PASSWORD`; `DB_HOST`/`DB_PORT` default `localhost`/`5432`) |
-| `PAYRAM_SSL_MODE` | `none` | `none`, `letsencrypt` (needs `DOMAIN_NAME` + `LE_EMAIL`), or `custom` (certs already in place) |
-| `PAYRAM_HOST_PORT` | `80` | HTTP host port. Bundled nginx proxies everything inside the container - 80 (+443 with TLS) are the only ports needed. Fails fast if busy |
-| `PAYRAM_NONINTERACTIVE` | auto (no TTY) | Set `1` to force headless prompts even with a TTY |
 | `PAYRAM_NODE_MODE` | `docker` | JS runtime: `docker` or `host` |
 | `PAYRAM_NODE_DOCKER_IMAGE` | `node:20-bullseye-slim` | Docker image used for JS scripts |
 | **deploy-scw** | | |
@@ -207,7 +201,7 @@ Rules agents must know:
 The one-step flow does:
 
 1. Network selection (`testnet` or `mainnet`) unless `PAYRAM_NETWORK` is set.
-2. Install or restart PayRam using `setup_payram.sh` (fresh install works headless — env-knob defaults; see Prerequisites).
+2. Install or restart PayRam using `setup_payram.sh` (fresh install asks its one-time questions in the terminal; see Prerequisites).
 3. Re-reads `config.env` and waits for API readiness at the real port.
 4. Auth (`setup` if no root user, else `signin`).
 5. `ensure-config` for local frontend/backend settings.

--- a/setup_payram.sh
+++ b/setup_payram.sh
@@ -8,21 +8,6 @@ set -euo pipefail
 # Supports: Ubuntu, Debian, CentOS, RHEL, Fedora, Arch, Alpine
 # =============================================================================
 
-# --- NON-INTERACTIVE (HEADLESS) INSTALL SUPPORT ---
-# When PAYRAM_NONINTERACTIVE=1 is set, or stdin is not a terminal, fresh-install
-# prompts stop blocking and resolve from environment variables with safe
-# defaults. Anything ambiguous fails fast with a clear message instead of
-# guessing. Interactive (TTY) behavior is unchanged unless a PAYRAM_* knob is
-# explicitly set. Knobs honored on a fresh install:
-#   PAYRAM_DB_MODE    internal (default) | external  — external needs DB_NAME,
-#                     DB_USER, DB_PASSWORD (DB_HOST/DB_PORT default localhost/5432)
-#   PAYRAM_SSL_MODE   none (default) | letsencrypt | custom — letsencrypt needs
-#                     DOMAIN_NAME + LE_EMAIL; custom needs DOMAIN_NAME + certs in place
-#   PAYRAM_HOST_PORT  host port published for HTTP (default 80; must be free)
-is_noninteractive() {
-  [[ "${PAYRAM_NONINTERACTIVE:-0}" == "1" || ! -t 0 ]]
-}
-
 # --- GLOBAL SYSTEM INFORMATION ---
 # Note: declare -g (bash 4.2+) is not used here; plain assignments work on bash 3.2+ (macOS default)
 OS_FAMILY=""
@@ -808,12 +793,6 @@ check_disk_space_requirements() {
       print_color "blue" "💡 Note: You can increase disk space after installation if needed."
       echo
       
-      if is_noninteractive; then
-        print_color "red" "❌ Not enough disk space for an unattended install (needs 5GB+ free)."
-        print_color "gray" "   Free space (docker system prune -a, apt clean) and re-run."
-        return 1
-      fi
-
       while true; do
         print_color "yellow" "Do you want to continue anyway? (y/N): "
         read -r response
@@ -971,26 +950,6 @@ configure_database() {
   print_color "gray" "   • Best for: Testing, development, and small-scale usage"
   echo
   
-  # Headless / env-pinned choice: PAYRAM_DB_MODE=internal|external.
-  # Unattended default is the containerized DB — zero extra inputs needed.
-  if [[ -n "${PAYRAM_DB_MODE:-}" ]] || is_noninteractive; then
-    case "${PAYRAM_DB_MODE:-internal}" in
-      external)
-        print_color "blue" "→ Database: external PostgreSQL (PAYRAM_DB_MODE)"
-        configure_external_database
-        ;;
-      internal)
-        print_color "blue" "→ Database: containerized PostgreSQL (${PAYRAM_DB_MODE:+via PAYRAM_DB_MODE=}${PAYRAM_DB_MODE:-headless default})"
-        configure_internal_database
-        ;;
-      *)
-        print_color "red" "❌ Invalid PAYRAM_DB_MODE='${PAYRAM_DB_MODE}'. Use 'internal' or 'external'."
-        exit 1
-        ;;
-    esac
-    return 0
-  fi
-
   while true; do
     read -e -p "Select option (1-2): " choice
     case $choice in
@@ -1018,34 +977,10 @@ configure_external_database() {
   print_color "gray" "  • Network connectivity (check firewalls if connection fails)"
   echo
   
-  # Headless: take connection details from the environment, test once, no retry
-  # loop. Required: DB_NAME, DB_USER, DB_PASSWORD. Optional: DB_HOST, DB_PORT.
-  if is_noninteractive; then
-    DB_HOST="${DB_HOST:-localhost}"
-    DB_PORT="${DB_PORT:-5432}"
-    local missing=""
-    [[ -z "${DB_NAME:-}" ]] && missing="$missing DB_NAME"
-    [[ -z "${DB_USER:-}" ]] && missing="$missing DB_USER"
-    [[ -z "${DB_PASSWORD:-}" ]] && missing="$missing DB_PASSWORD"
-    if [[ -n "$missing" ]]; then
-      print_color "red" "❌ External DB selected but missing env:${missing}"
-      print_color "gray" "   Export them and re-run, or use PAYRAM_DB_MODE=internal."
-      exit 1
-    fi
-    print_color "blue" "🔍 Testing database connection (headless)..."
-    if test_postgres_connection; then
-      print_color "green" "✅ Database connection successful!"
-      return 0
-    fi
-    print_color "red" "❌ Could not connect to ${DB_HOST}:${DB_PORT}/${DB_NAME} as ${DB_USER}."
-    print_color "gray" "   Check host/credentials/firewall, or use PAYRAM_DB_MODE=internal."
-    exit 1
-  fi
-
   while true; do
     read -e -p "Database Host [localhost]: " DB_HOST
     DB_HOST=${DB_HOST:-localhost}
-
+    
     read -e -p "Database Port [5432]: " DB_PORT
     DB_PORT=${DB_PORT:-5432}
     
@@ -1172,31 +1107,6 @@ configure_ssl() {
   print_color "gray" "   • You can add SSL certificates anytime when ready"
   echo
 
-  # Headless / env-pinned choice: PAYRAM_SSL_MODE=none|letsencrypt|custom.
-  # Unattended default is none (HTTP) — SSL needs DNS facts an agent may not
-  # have; it can be added later via the SSL update flow.
-  if [[ -n "${PAYRAM_SSL_MODE:-}" ]] || is_noninteractive; then
-    case "${PAYRAM_SSL_MODE:-none}" in
-      letsencrypt)
-        print_color "blue" "→ SSL: Let's Encrypt (PAYRAM_SSL_MODE)"
-        configure_ssl_letsencrypt
-        ;;
-      custom)
-        print_color "blue" "→ SSL: custom certificates (PAYRAM_SSL_MODE)"
-        configure_ssl_custom
-        ;;
-      none|external)
-        print_color "blue" "→ SSL: none for now (${PAYRAM_SSL_MODE:+via PAYRAM_SSL_MODE=}${PAYRAM_SSL_MODE:-headless default}) — HTTP on port 80"
-        configure_ssl_external
-        ;;
-      *)
-        print_color "red" "❌ Invalid PAYRAM_SSL_MODE='${PAYRAM_SSL_MODE}'. Use 'none', 'letsencrypt', or 'custom'."
-        exit 1
-        ;;
-    esac
-    return 0
-  fi
-
   while true; do
     read -e -p "Select option (1-3): " choice
     case $choice in
@@ -1230,34 +1140,40 @@ configure_ssl_letsencrypt() {
   print_color "gray" "  • No other web server using these ports"
   echo
   
-  # Headless: domain + email must come from the environment — there is no
-  # sane default for DNS facts. Fail fast with the exact knobs to set.
-  if is_noninteractive; then
-    if [[ -z "${DOMAIN_NAME:-}" || -z "${LE_EMAIL:-}" ]]; then
-      print_color "red" "❌ PAYRAM_SSL_MODE=letsencrypt needs DOMAIN_NAME and LE_EMAIL env vars."
-      print_color "gray" "   Export both and re-run, or use PAYRAM_SSL_MODE=none and add SSL later."
-      exit 1
-    fi
-  fi
-
-  # Domain input with validation (skipped when DOMAIN_NAME is pre-set)
-  while [[ -z "${DOMAIN_NAME:-}" ]] || [[ ! "$DOMAIN_NAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$ ]]; do
-    if [[ -n "${DOMAIN_NAME:-}" ]]; then
-      print_color "red" "Invalid domain format. Please use format: payram.example.com"
-      if is_noninteractive; then exit 1; fi
-    fi
+  # Domain input with validation
+  while true; do
     read -e -p "Enter your domain name (e.g., payram.example.com): " DOMAIN_NAME
-    [[ -z "$DOMAIN_NAME" ]] && print_color "red" "Domain name cannot be empty"
-  done
-
-  # Email for Let's Encrypt notifications (skipped when LE_EMAIL is pre-set)
-  while [[ -z "${LE_EMAIL:-}" ]] || [[ ! "$LE_EMAIL" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; do
-    if [[ -n "${LE_EMAIL:-}" ]]; then
-      print_color "red" "Invalid email format"
-      if is_noninteractive; then exit 1; fi
+    
+    if [[ -z "$DOMAIN_NAME" ]]; then
+      print_color "red" "Domain name cannot be empty"
+      continue
     fi
+    
+    # Basic domain validation
+    if [[ ! "$DOMAIN_NAME" =~ ^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$ ]]; then
+      print_color "red" "Invalid domain format. Please use format: payram.example.com"
+      continue
+    fi
+    
+    break
+  done
+  
+  # Email for Let's Encrypt notifications
+  while true; do
     read -e -p "Enter email for SSL notifications (certificate expiry alerts): " LE_EMAIL
-    [[ -z "$LE_EMAIL" ]] && print_color "red" "Email cannot be empty"
+    
+    if [[ -z "$LE_EMAIL" ]]; then
+      print_color "red" "Email cannot be empty"
+      continue
+    fi
+    
+    # Basic email validation
+    if [[ ! "$LE_EMAIL" =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+      print_color "red" "Invalid email format"
+      continue
+    fi
+    
+    break
   done
   
   echo
@@ -1267,14 +1183,7 @@ configure_ssl_letsencrypt() {
   print_color "gray" "  • This process takes 1-3 minutes"
   echo
   
-  local confirm
-  if is_noninteractive; then
-    # Headless: PAYRAM_SSL_MODE=letsencrypt + DOMAIN_NAME + LE_EMAIL already
-    # encode explicit intent — proceed without blocking.
-    confirm="y"
-  else
-    read -e -p "Ready to generate SSL certificate? (y/N): " confirm
-  fi
+  read -e -p "Ready to generate SSL certificate? (y/N): " confirm
   if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     print_color "yellow" "SSL setup cancelled. Continuing without SSL..."
     SSL_CERT_PATH=""
@@ -1312,13 +1221,6 @@ configure_ssl_letsencrypt() {
     print_color "gray" "  • Another web server is running"
     echo
     
-    if is_noninteractive; then
-      # Headless: don't silently downgrade an explicit letsencrypt request to
-      # HTTP — fail with the fix list above, or re-run with PAYRAM_SSL_MODE=none.
-      print_color "red" "❌ Certificate generation failed (headless). Fix the issues above and re-run,"
-      print_color "gray" "   or re-run with PAYRAM_SSL_MODE=none to install on HTTP now and add SSL later."
-      exit 1
-    fi
     read -e -p "Continue without SSL? (y/N): " continue_without_ssl
     if [[ "$continue_without_ssl" =~ ^[Yy]$ ]]; then
       SSL_CERT_PATH=""
@@ -1426,14 +1328,7 @@ configure_ssl_external() {
   print_color "red" "  • Restrict direct access to PayRam ports (firewall rules)"
   echo
   
-  local confirm_external
-  if is_noninteractive; then
-    # Headless: reaching this function already encodes the no-SSL choice
-    # (PAYRAM_SSL_MODE=none or headless default) — don't block on a confirm.
-    confirm_external="y"
-  else
-    read -e -p "Do you want to continue with external SSL management? (y/N): " confirm_external
-  fi
+  read -e -p "Do you want to continue with external SSL management? (y/N): " confirm_external
   if [[ "$confirm_external" =~ ^[Yy]$ ]]; then
     SSL_CERT_PATH=""
     SSL_MODE="external"
@@ -1697,9 +1592,7 @@ generate_aes_key() {
   print_color "red" "  • Regular withdrawal of excess funds to cold wallet"
   echo
   
-  if ! is_noninteractive; then
-    read -e -p "Press [Enter] to generate AES-256 encryption key for hot wallet..."
-  fi
+  read -e -p "Press [Enter] to generate AES-256 encryption key for hot wallet..."
   
   print_color "cyan" "🔮 Summoning cryptographic magic..."
   print_color "yellow" "⚡ Generating quantum-secure randomness..."
@@ -1919,24 +1812,6 @@ configure_port_mapping() {
     fi
     PRIMARY_PORT_MAPPING="80:80 443:443"
     log "INFO" "Port mapping set to $PRIMARY_PORT_MAPPING (internal TLS)"
-    return 0
-  fi
-
-  # Headless / env-pinned: PAYRAM_HOST_PORT picks the published HTTP port
-  # (default 80). Validate once and fail fast — no prompt loop to hang on.
-  if [[ -n "${PAYRAM_HOST_PORT:-}" ]] || is_noninteractive; then
-    host_port="${PAYRAM_HOST_PORT:-80}"
-    if [[ ! "$host_port" =~ ^[0-9]+$ ]] || (( host_port < 1 || host_port > 65535 )); then
-      print_color "red" "❌ Invalid PAYRAM_HOST_PORT='${host_port}'. Use a number between 1 and 65535."
-      exit 1
-    fi
-    if ! is_port_free "$host_port"; then
-      print_color "red" "❌ Host port $host_port is already in use."
-      print_color "gray" "   Find the listener: sudo lsof -i :$host_port — stop it, or set PAYRAM_HOST_PORT to a free port (e.g. 8080)."
-      exit 1
-    fi
-    PRIMARY_PORT_MAPPING="${host_port}:80"
-    log "INFO" "Port mapping set to $PRIMARY_PORT_MAPPING (${PAYRAM_HOST_PORT:+via PAYRAM_HOST_PORT=}${PAYRAM_HOST_PORT:-headless default})"
     return 0
   fi
 
@@ -4192,9 +4067,7 @@ main() {
   print_color "gray" "  • Backup critical: AES key + database data"
   echo
   
-  if ! is_noninteractive; then
-    read -e -p "Press [Enter] to deploy PayRam container..."
-  fi
+  read -e -p "Press [Enter] to deploy PayRam container..."
   
   # Step 7: Deploy container
   if deploy_payram_container; then

--- a/setup_payram_agents.sh
+++ b/setup_payram_agents.sh
@@ -54,11 +54,8 @@ Headless commands:
 Env vars:
 	PAYRAM_NETWORK (testnet|mainnet)
 	PAYRAM_SETUP_MODE (merchant|operator; default merchant)
-	Headless fresh-install knobs (no TTY needed; every prompt resolves from env):
-	PAYRAM_DB_MODE (internal|external; default internal. external needs DB_NAME, DB_USER, DB_PASSWORD [+DB_HOST, DB_PORT])
-	PAYRAM_SSL_MODE (none|letsencrypt|custom; default none. letsencrypt needs DOMAIN_NAME + LE_EMAIL)
-	PAYRAM_HOST_PORT (HTTP host port; default 80 - the bundled nginx proxies everything inside the container. Fails fast if 80 is busy)
-	PAYRAM_NONINTERACTIVE=1 (force headless even with a TTY)
+	Fresh install: needs a terminal once (the installer asks DB/SSL/port).
+	Every step AFTER the install runs fully headless.
 	PAYRAM_OPERATOR_BTC_FEE_COLLECTOR, PAYRAM_OPERATOR_EVM_FEE_COLLECTOR
 	PAYRAM_OPERATOR_FEE_BPS (default 100 = 1%, max 1500)
 	PAYRAM_API_URL (default: derived from installed config.env / running container)
@@ -621,20 +618,17 @@ troubleshoot() {
 			fi
 			;;
 		install-interactive)
-			echo "The install did not complete. Headless installs resolve every choice from"
-			echo "env vars (defaults: internal DB, no SSL, port 80/first free) - the message"
-			echo "above this one names the exact problem. Most likely:"
-			echo "  [40%] Chosen host port is busy."
-			echo "        -> PAYRAM_HOST_PORT=8080 $0 --testnet   (or stop the listener)"
-			echo "  [25%] Disk below the 5GB minimum."
-			echo "        -> docker system prune -a; apt clean; then re-run"
-			echo "  [20%] PAYRAM_SSL_MODE=letsencrypt without DOMAIN_NAME/LE_EMAIL set,"
-			echo "        or PAYRAM_DB_MODE=external without DB_NAME/DB_USER/DB_PASSWORD."
-			echo "        -> export the named vars, or drop back to the defaults"
-			echo "  [10%] Docker missing / image pull failed (network)."
-			echo "        -> docker version; docker logs payram 2>&1 | tail -20"
-			echo "  [ 5%] Container exists but is stopped."
+			echo "Fresh install needs a terminal: setup_payram.sh asks one-time DB/SSL/port"
+			echo "questions. Everything AFTER the install is fully headless."
+			echo "  [70%] You ran the one-step flow without a TTY before PayRam was installed."
+			echo "        -> run once from a terminal: sudo ./setup_payram.sh --mainnet (or --testnet)"
+			echo "           then re-run this agent flow (it attaches to the existing install)."
+			echo "  [15%] The installer reported an error above (disk, docker, port busy) -"
+			echo "        fix what it printed and re-run."
+			echo "  [10%] Container exists but is stopped."
 			echo "        -> $0 --restart"
+			echo "  [ 5%] Docker missing / image pull failed (network)."
+			echo "        -> docker version; docker logs payram 2>&1 | tail -20"
 			;;
 		auth-env)
 			echo "Credentials are required but no terminal is available to prompt."
@@ -2279,22 +2273,18 @@ flow_main() {
 		log "Restarting PayRam container..."
 		(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --restart)
 	elif ! is_payram_running; then
-		# A FRESH install delegates to setup_payram.sh and ALWAYS runs it with
-		# zero questions: every choice resolves from PAYRAM_* env knobs with
-		# deterministic defaults (internal DB, no SSL, port 80). The bundled
-		# nginx inside the container reverse-proxies everything - 80 (and 443
-		# with TLS) are the only ports PayRam needs. If 80 is busy the
-		# installer fails fast with the listener + the PAYRAM_HOST_PORT
-		# override; we don't silently pick another port (links on :8080
-		# surprise people). Config-comes-later UX: SSL, ports, and DB can all
-		# be changed once the gateway works - the goal here is the payment
-		# link. Full interactive installer: sudo ./setup_payram.sh
-		export PAYRAM_NONINTERACTIVE=1
-		export PAYRAM_DB_MODE="${PAYRAM_DB_MODE:-internal}"
-		export PAYRAM_SSL_MODE="${PAYRAM_SSL_MODE:-none}"
-		log "Install defaults: DB=${PAYRAM_DB_MODE} SSL=${PAYRAM_SSL_MODE} port=${PAYRAM_HOST_PORT:-80} (${network_mode})"
-		log "All of this is changeable later - SSL included. Overrides: PAYRAM_DB_MODE / PAYRAM_SSL_MODE / PAYRAM_HOST_PORT."
+		# A FRESH install delegates to setup_payram.sh - the working installer
+		# from main, UNMODIFIED. It asks its one-time DB/SSL/port questions
+		# interactively, so this single step needs a terminal; everything
+		# after the install is fully headless. Without a TTY, fail fast with
+		# directions instead of letting the installer's prompts die on EOF.
+		if [[ ! -t 0 ]]; then
+			troubleshoot install-interactive
+			exit 1
+		fi
 		log "Installing/starting PayRam (${network_mode})..."
+		log "The installer will ask a few one-time questions (database, SSL, port)."
+		log "Tip: defaults are fine to start - SSL and ports can be changed later."
 		local install_rc=0
 		if [[ "$network_mode" == "mainnet" ]]; then
 			(cd "$SCRIPT_DIR" && run_as_root ./setup_payram.sh --mainnet) || install_rc=$?


### PR DESCRIPTION
Scope correction per review: **`setup_payram.sh` is restored byte-for-byte to main's working version** (diff vs origin/main = 0). The agent work's scope is `setup_payram_agents.sh` only.

Accepted consequence: a fresh install needs a terminal once (the installer asks its one-time DB/SSL/port questions; defaults are fine). The agent flow fails fast with clear directions when no TTY, and **everything after the install remains fully headless**. Headless env knobs removed from the agent script, usage, troubleshoot card, and doc.

All agent-side improvements stay (Base-USDC MVF, either-chain funding, zero-input auth, V2 ABI fix, version-spanning API calls). Release PR #63 updates automatically.